### PR TITLE
Fix TV video alignment and improve hover effect on Navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,9 +136,9 @@
           and TV.</span
         >
       </div>
-      <div class="secImg">
+      <div class="imgno3">
         <img
-          src="https://assets.nflxext.com/ffe/siteui/acquisition/ourStory/fuji/desktop/tv.png"
+          src="https://assets.nflxext.com/ffe/siteui/acquisition/ourStory/fuji/desktop/device-pile-in.png"
           alt="Devices"
         />
         <video

--- a/style.css
+++ b/style.css
@@ -308,7 +308,7 @@ html {
   padding: 100px 50px;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 80px;
+  gap: 50px;
   align-items: center;
   max-width: 1200px;
   margin: 0 auto;
@@ -337,28 +337,47 @@ html {
   line-height: 1.4;
 }
 
+/* For 1st TV and vedio */
 .secImg {
   position: relative;
 }
 .secImg img {
-  width: 100%;
-  height: auto;
-  border-radius: 8px;
+  position:relative;
+    z-index: 10;
+    width:490px
 }
 .secImg:hover {
-  transform: scale(1.05) rotate(1deg);
+  transform: scale(1.05) rotate(0.05deg);
 }
 .secImg video {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 70%;
-  height: auto;
-  z-index: 1;
-  border-radius: 4px;
+    max-width: 360px;
+    top: 75px;
+    left: 65px;
+}
+/*For 2nd TV and vedio */
+.imgno3{
+    position: relative;
+}
+.imgno3 img{
+    position: relative;
+    padding-top: 50px;
+    height:408px;
+    width: 544px;
+    z-index: 10;
+}
+.imgno3:hover {
+  transform: scale(1.05) rotate(0.05deg);
+}
+.imgno3 video{
+    position: absolute;
+    height: 280px;
+    width: 350px;
+    top:65px;
+    left: 100px;
 }
 
+/*Frequent ask question  */
 
 .faq {
   padding: 100px 50px;


### PR DESCRIPTION
 PR Description:
This pull request addresses Issue #164 by making the following UI improvements:

🔧 Changes Made:
Fixed the alignment between the video and the TV frame
Improved the hover effect on the Bookmarks button (and possibly others)
Replaced the duplicate TV image with a cleaner and more visually appealing version

📉 Before:
The video was not properly aligned with the TV screen
Hover effects were inconsistent and visually weak
A duplicate TV image was being used, reducing the quality of the UI

https://github.com/user-attachments/assets/406b30fd-9e95-4937-8849-3544b6c5ae9d


📈 After:
The video is now properly synced and aligned within the TV frame
Hover effects are now smoother and more visually consistent
TV image is replaced with a single, better-quality graphic


https://github.com/user-attachments/assets/33af4eae-b16a-4777-8223-0ef375ea4a90

<img width="1827" height="917" alt="Screenshot 2025-08-05 201301" src="https://github.com/user-attachments/assets/03dc1627-5d5a-40b2-b1d5-1d50438af152" />






